### PR TITLE
Fix Garbage character printed after printing Image

### DIFF
--- a/bitimage.go
+++ b/bitimage.go
@@ -23,7 +23,7 @@ func printImage(img image.Image) (xL byte, xH byte, yL byte, yH byte, data []byt
 	printHeight := closestNDivisibleBy8(height)
 	bytes, _ := rasterize(printWidth, printHeight, &pixels)
 
-	return byte((width >> 3) & 0xff), byte(((width >> 3) >> 8) & 0xff), byte(height & 0xff), byte((height >> 8) & 0xff), bytes
+	return byte((printWidth >> 3) & 0xff), byte(((printWidth >> 3) >> 8) & 0xff), byte(printHeight & 0xff), byte((printHeight >> 8) & 0xff), bytes
 }
 
 func makeGrayscale(pixels *[][]pixel) {


### PR DESCRIPTION
Printer: [THERMAL 58MM EPPOS RPP02](https://www.tokopedia.com/barcodezone/moka-pos-printer-bluetooth-ppob-pos-thermal-58mm-eppos-rpp02-kasir)
Example Image printed (220px x 220px): 
![test](https://user-images.githubusercontent.com/65433713/201291074-58c6ccca-178b-4ab3-875b-776246188e96.png)


When i try to print an image multiple times without delay between `.WriteRaw()` , garbage characters are printed out like this example:
![1](https://user-images.githubusercontent.com/65433713/201290422-9790a66a-bd8e-40c2-9add-faccaee2442c.jpeg)

After reading and searching for more detailed documentation, i ran across this doc:
https://aures-support.com/DATA/drivers/Imprimantes/Commande%20ESCPOS.pdf

which state about raster bit image printing:
```
k (length of bytes) = (xL + xH x 256) x (yL + yH x 256)      (k≠0)
```

So after debugging the value of `xL xH yL yH and len(data)` from the above image (220px 220px)
the value returned by `printImage` is 
```
xL = 27
xH = 0
yL = 220
yH = 0 and len(data) = 5832

(27 + 0 x 256) x (220 + 0 x 256) = 5940
5940 != 5832
```
Which result in the garbage character that should be the next characters for next image

So after change the code a little bit, the result is
```
xL = 27
xH = 0
yL = 216
yH = 0 and len(data) = 5832

(27 + 0 x 256) x (216 + 0 x 256) = 5832
5832 == 5832
```
Printing 3 image in a row:
![2](https://user-images.githubusercontent.com/65433713/201292590-7b7f2867-cb70-4b63-af04-8e9c019956d3.jpeg)





